### PR TITLE
fix install instruction with latest go's

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ show golang dependence like tree
 ## How to get it
 
 ```shell
-➜ go get -u github.com/vc60er/deptree
+➜ go install github.com/vc60er/deptree@latest
 ➜ export PATH=$PATH:$GOPATH/bin
 ```
 


### PR DESCRIPTION
For fix next unexpected behaviour
```
asmyasnikov@asmyasnikov-x ~ % go get github.com/vc60er/deptree
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
asmyasnikov@asmyasnikov-x ~ % go get github.com/vc60er/deptree@latest
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
asmyasnikov@asmyasnikov-x ~ % go install github.com/vc60er/deptree@latest
```