### PR TITLE
QUICKFIX: maxDepth for route creation depends on depth parameter

### DIFF
--- a/internal/tree/route.go
+++ b/internal/tree/route.go
@@ -32,14 +32,22 @@ type routeTreeLine struct {
 type routeTreeLines []*routeTreeLine
 
 type routeTree struct {
-	lines *routeTreeLines
+	maxDepth int
+	lines    *routeTreeLines
 }
 
 var colorDefinition = map[string]string{upgradeMarker: colorYellow}
 
 // printRoute prints out the tree as route to the console
 func (t *tree) printRoute() {
-	rt := routeTree{lines: &routeTreeLines{}}
+	rt := routeTree{
+		maxDepth: t.depth,
+		lines:    &routeTreeLines{},
+	}
+	if t.visualizeTrimmed {
+		// to prepare the route for "..." lines, we need one level more
+		rt.maxDepth++
+	}
 
 	// evaluate data and apply filters
 	rt.processItem("", *t.rootItem, nil)
@@ -87,7 +95,7 @@ func (t *tree) printRoute() {
 
 // processItem add lines with route sign etc. starting at the given item
 func (rt *routeTree) processItem(route string, item treeItem, parentLine *routeTreeLine) int {
-	if (len([]rune(string(route)))+1)/5 > maxDepth {
+	if (len([]rune(string(route)))+1)/5 > rt.maxDepth {
 		return -1
 	}
 	line := rt.createAndAddLine(route, item, parentLine)

--- a/internal/tree/tree.go
+++ b/internal/tree/tree.go
@@ -90,8 +90,23 @@ func (t *tree) addItem(name string, childName string) *treeItem {
 	}
 
 	if len(childName) > 0 {
+		if name == childName {
+			log.Fatalf("circular dependency for %s", name)
+		}
+		if contains(item.children, childName) {
+			log.Fatalf("try to add duplicate children %s", childName)
+		}
 		item.children = append(item.children, t.addItem(childName, ""))
 	}
 
 	return item
+}
+
+func contains(items []*treeItem, searchName string) bool {
+	for _, item := range items {
+		if item.module.Name() == searchName {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/tree/tree_example_test.go
+++ b/internal/tree/tree_example_test.go
@@ -31,7 +31,7 @@ func ExamplePrint_all() {
 	t.Fill(graphStringReader())
 	t.Print(false)
 	// Output:
-	// dependency tree with depth 2 for package: github.com/vc60er/deptree, least 2 trimmed item(s) (no visualization for trimmed tree)
+	// dependency tree with depth 2 for package: github.com/vc60er/deptree (no visualization for trimmed tree)
 	//
 	// github.com/vc60er/deptree
 	//  └── github.com/stretchr/testify@v1.8.2


### PR DESCRIPTION
this change provides a possible workaround for #10 , not really a fix
but in general it is a good idea to save time and memory by reducing the maxDepth to the really needed one

in addition it prevents direct circular dependencies and duplicated child entries