### PR TITLE
Fix/hang or recursion

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,95 @@
+
+linters:
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - containedctx
+    - contextcheck
+    - decorder
+    - depguard
+    - dogsled
+    - dupl
+    - dupword
+    - durationcheck
+    - errcheck
+    - errchkjson
+    - errname
+    - errorlint
+    - execinquery
+    - exhaustive
+    - exportloopref
+    - forcetypeassert
+    - gci
+    - ginkgolinter
+    - gocheckcompilerdirectives
+    - gochecknoinits
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goheader
+    - goimports
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - grouper
+    - importas
+    - ineffassign
+    - interfacebloat
+    - ireturn
+    - loggercheck
+    - maintidx
+    - makezero
+    - misspell
+    - nakedret
+    - nestif
+    - nilerr
+    - nilnil
+    - noctx
+    - nolintlint
+    - nonamedreturns
+    - nosprintfhostport
+    - predeclared
+    - promlinter
+    - reassign
+    - revive
+    - rowserrcheck
+    - sqlclosecheck
+    - staticcheck
+    - stylecheck
+    - tenv
+    - testableexamples
+    - thelper
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+    - wastedassign
+    - whitespace
+
+linters-settings:
+  gocognit:
+    # Minimal code complexity to report.
+    # Default: 30 (but we recommend 10-20)
+    min-complexity: 45
+
+  nestif:
+    # Minimal complexity of if statements to report.
+    # Default: 5
+    min-complexity: 10
+
+  revive:
+    rules:
+      - name: unexported-return
+        severity: warning
+        disabled: true

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: build
 
 .PHONY: build
 build:
-	go build -o output/deptree -v deptree.go
+	go build -v -o output/deptree
 
 .PHONY: test
 test:
@@ -16,7 +16,8 @@ test_example:
 # Test, generate and show coverage in browser
 .PHONY: test_cover
 test_cover:
-	go test -v -run Test ./... -coverprofile=output/coverage.txt ; \
+	mkdir -p output ; \
+	go test -count=1 -v -run Test ./... -coverprofile=output/coverage.txt ; \
 	go tool cover -html=output/coverage.txt ; \
 
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ show golang dependence like tree
 
 ```text
 Usage of deptree:
-  -a  show all dependencies, not only with upgrade
+  -a  show all dependencies, also without upgrade and point out duplicated children
+  -c  upgrade candidates will be marked yellow
   -d int
       max depth of dependencies (default 3)
+  -f  force show of each occurrence of a child branch in tree (can cause hang)
   -graph string
       path to file created e.g. by 'go mod graph > grapphfile.txt'
   -json
@@ -25,13 +27,18 @@ Usage of deptree:
   -t  visualize trimmed tree by '└─...'
   -upgrade string
       path to file created e.g. by 'go list -u -m -json all > upgradefile.txt'
+  -v int
+      be more verbose
 ```
 
 ### example
 
 ```shell
 ➜  redis git:(master) go mod graph | deptree -d 2 -t -a
-dependency tree with depth 2 for package: gobot.io/x/gobot, least 622 trimmed item(s)
+call 'go list -u -m -json all', be patient...
+dependency tree with depth 2 for package: gobot.io/x/gobot, least 99 trimmed item(s)
+* tree of duplicate children not drawn (-f not set)
+* 12 duplicate child trees replaced by links
 
 gobot.io/x/gobot (go1.17)
  ├── github.com/bmizerany/pat@v0.0.0-20210406213842-e4b6760bdd6f
@@ -42,180 +49,166 @@ gobot.io/x/gobot (go1.17)
  ├── github.com/donovanhide/eventsource@v0.0.0-20210830082556-c59027999da0
  ├── github.com/eclipse/paho.mqtt.golang@v1.4.1 (go1.14) => [v1.4.2]
  │    ├── github.com/gorilla/websocket@v1.4.2 => [v1.5.0] (go1.12)
- │    ├── golang.org/x/net@v0.0.0-20200425230154-ff2c4b7c35a0 => [v0.9.0]
- │    │    └── ...
- │    └── golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c => [v0.1.0]
+ │    ├── golang.org/x/net@v0.0.0-20200425230154-ff2c4b7c35a0 => [v0.10.0]
+ │    │    └── 3 more ...
+ │    └── golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c => [v0.2.0]
  ├── github.com/fatih/structs@v1.1.0
- ├── github.com/go-ole/go-ole@v1.2.6 (go1.12)
- │    └── golang.org/x/sys@v0.0.0-20190916202348-b4ddaad3f8a3 => [v0.7.0]
+ ├── <2> github.com/go-ole/go-ole@v1.2.6 (go1.12)
+ │    └── golang.org/x/sys@v0.0.0-20190916202348-b4ddaad3f8a3 => [v0.8.0]
  ├── github.com/godbus/dbus/v5@v5.1.0 (go1.12)
  ├── github.com/gofrs/uuid@v4.3.0+incompatible => [v4.4.0+incompatible]
- ├── github.com/golang/protobuf@v1.5.0 (go1.9) => [v1.5.3]
- │    ├── github.com/google/go-cmp@v0.5.5 (go1.8) => [v0.5.9]
- │    │    └── ...
+ ├── <7> github.com/golang/protobuf@v1.5.0 (go1.9) => [v1.5.3]
+ │    ├── <8> github.com/google/go-cmp@v0.5.5 (go1.8) => [v0.5.9]
+ │    │    └── 1 more ...
  │    └── google.golang.org/protobuf@v1.26.0-rc.1 => [v1.30.0]
- │         └── ...
+ │         └── 1 more ...
  ├── github.com/gorilla/websocket@v1.5.0 (go1.12)
  ├── github.com/hashicorp/errwrap@v1.1.0
  ├── github.com/hashicorp/go-multierror@v1.1.1 (go1.13)
  │    └── github.com/hashicorp/errwrap@v1.0.0 => [v1.1.0]
  ├── github.com/hybridgroup/go-ardrone@v0.0.0-20140402002621-b9750d8d7b78
  ├── github.com/hybridgroup/mjpeg@v0.0.0-20140228234708-4680f319790e
- ├── github.com/muka/go-bluetooth@v0.0.0-20220830075246-0746e3a1ea53 (go1.14) => [v0.0.0-20221213043340-85dc80edc4e1]
+ ├── <10> github.com/muka/go-bluetooth@v0.0.0-20220830075246-0746e3a1ea53 (go1.14) => [v0.0.0-20221213043340-85dc80edc4e1]
  │    ├── github.com/fatih/structs@v1.1.0
  │    ├── github.com/godbus/dbus/v5@v5.0.3 => [v5.1.0] (go1.12)
  │    ├── github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e (go1.12)
- │    │    └── ...
+ │    │    └── 1 more ...
  │    ├── github.com/pkg/errors@v0.9.1
  │    ├── github.com/sirupsen/logrus@v1.6.0 => [v1.9.0] (go1.13)
- │    │    └── ...
+ │    │    └── 5 more ...
  │    ├── github.com/stretchr/testify@v1.6.1 => [v1.8.2]
- │    │    └── ...
+ │    │    └── 4 more ...
  │    ├── github.com/suapapa/go_eddystone@v1.3.1 (go1.14)
- │    │    └── ...
- │    ├── golang.org/x/sys@v0.0.0-20200728102440-3e129f6d46b1 => [v0.7.0]
- │    ├── golang.org/x/tools@v0.0.0-20200925191224-5d1fdd8fa346 => [v0.8.0]
- │    │    └── ...
+ │    │    └── 2 more ...
+ │    ├── golang.org/x/sys@v0.0.0-20200728102440-3e129f6d46b1 => [v0.8.0]
+ │    ├── golang.org/x/tools@v0.0.0-20200925191224-5d1fdd8fa346 => [v0.9.1]
+ │    │    └── 5 more ...
  │    └── gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f => [v1.0.0-20201130134442-10cb98267c6c]
- ├── github.com/nats-io/nats-server/v2@v2.1.0 => [v2.9.15]
+ ├── github.com/nats-io/nats-server/v2@v2.1.0 => [v2.9.16]
  │    ├── github.com/golang/protobuf@v1.3.2 => [v1.5.3]
  │    ├── github.com/nats-io/jwt@v0.3.0 => [v1.2.2]
- │    │    └── ...
+ │    │    └── 1 more ...
  │    ├── github.com/nats-io/nats.go@v1.8.1 => [v1.25.0]
- │    │    └── ...
+ │    │    └── 2 more ...
  │    ├── github.com/nats-io/nkeys@v0.1.0 => [v0.4.4]
- │    │    └── ...
+ │    │    └── 1 more ...
  │    ├── github.com/nats-io/nuid@v1.0.1
- │    ├── golang.org/x/crypto@v0.0.0-20190701094942-4def268fd1a4 => [v0.8.0]
- │    │    └── ...
- │    └── golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e => [v0.7.0]
+ │    ├── golang.org/x/crypto@v0.0.0-20190701094942-4def268fd1a4 => [v0.9.0]
+ │    │    └── 2 more ...
+ │    └── golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e => [v0.8.0]
  ├── github.com/nats-io/nats.go@v1.18.0 (go1.16) => [v1.25.0]
- │    ├── github.com/nats-io/nkeys@v0.3.0 (go1.16) => [v0.4.4]
- │    │    └── ...
+ │    ├── github.com/nats-io/nkeys@v0.3.0 (go1.16) => [v0.4.4], see <1> for 1 children (branch 'gobot.io/x/gobot' level 1)
  │    └── github.com/nats-io/nuid@v1.0.1
- ├── github.com/nats-io/nkeys@v0.3.0 (go1.16) => [v0.4.4]
- │    └── golang.org/x/crypto@v0.0.0-20210314154223-e6e6c4f2bb5b => [v0.8.0]
- │         └── ...
+ ├── <1> github.com/nats-io/nkeys@v0.3.0 (go1.16) => [v0.4.4]
+ │    └── golang.org/x/crypto@v0.0.0-20210314154223-e6e6c4f2bb5b => [v0.9.0]
+ │         └── 3 more ...
  ├── github.com/nats-io/nuid@v1.0.1
  ├── github.com/pkg/errors@v0.9.1
  ├── github.com/pmezard/go-difflib@v1.0.0
  ├── github.com/russross/blackfriday/v2@v2.1.0
- ├── github.com/saltosystems/winrt-go@v0.0.0-20220913104103-712830fcd2ad (go1.18) => [v0.0.0-20230124093143-967a889c6c8f]
+ ├── github.com/saltosystems/winrt-go@v0.0.0-20220913104103-712830fcd2ad (go1.18) => [v0.0.0-20230510070731-e096b9afa761]
  │    ├── github.com/glerchundi/subcommands@v0.0.0-20181212083838-923a6ccb11f8
  │    ├── github.com/go-kit/log@v0.2.1 (go1.17)
- │    │    └── ...
- │    ├── github.com/go-ole/go-ole@v1.2.6 (go1.12)
- │    │    └── ...
- │    ├── github.com/peterbourgon/ff/v3@v3.1.2 (go1.16) => [v3.3.0]
- │    │    └── ...
+ │    │    └── 1 more ...
+ │    ├── github.com/go-ole/go-ole@v1.2.6 (go1.12), see <2> for 1 children (branch 'gobot.io/x/gobot' level 1)
+ │    ├── github.com/peterbourgon/ff/v3@v3.1.2 (go1.16) => [v3.3.1]
+ │    │    └── 2 more ...
  │    ├── github.com/stretchr/testify@v1.7.5 => [v1.8.2]
- │    │    └── ...
+ │    │    └── 4 more ...
  │    ├── github.com/tdakkota/win32metadata@v0.1.0 (go1.16)
- │    │    └── ...
- │    ├── golang.org/x/tools@v0.1.11 (go1.17) => [v0.8.0]
- │    │    └── ...
+ │    │    └── 2 more ...
+ │    ├── golang.org/x/tools@v0.1.11 (go1.17) => [v0.9.1]
+ │    │    └── 6 more ...
  │    ├── github.com/davecgh/go-spew@v1.1.1
  │    ├── github.com/go-logfmt/logfmt@v0.5.1 (go1.17) => [v0.6.0]
  │    ├── github.com/pmezard/go-difflib@v1.0.0
  │    ├── golang.org/x/mod@v0.6.0-dev.0.20220419223038-86c51ed26bb4 (go1.17) => [v0.10.0]
- │    │    └── ...
- │    ├── golang.org/x/sys@v0.0.0-20220624220833-87e55d714810 => [v0.7.0]
- │    └── gopkg.in/yaml.v3@v3.0.1
- │         └── ...
+ │    │    └── 2 more ...
+ │    ├── golang.org/x/sys@v0.0.0-20220624220833-87e55d714810 => [v0.8.0]
+ │    └── gopkg.in/yaml.v3@v3.0.1, see <3> for 1 children (branch 'gobot.io/x/gobot' level 1)
  ├── github.com/sigurn/crc8@v0.0.0-20220107193325-2243fe600f9f (go1.17)
- ├── github.com/sirupsen/logrus@v1.9.0 (go1.13)
+ ├── <11> github.com/sirupsen/logrus@v1.9.0 (go1.13)
  │    ├── github.com/davecgh/go-spew@v1.1.1
- │    ├── github.com/stretchr/testify@v1.7.0 => [v1.8.2]
- │    │    └── ...
- │    └── golang.org/x/sys@v0.0.0-20220715151400-c0bba94af5f8 => [v0.7.0]
+ │    ├── <5> github.com/stretchr/testify@v1.7.0 => [v1.8.2]
+ │    │    └── 4 more ...
+ │    └── golang.org/x/sys@v0.0.0-20220715151400-c0bba94af5f8 => [v0.8.0]
  ├── github.com/stretchr/testify@v1.8.0 (go1.13) => [v1.8.2]
  │    ├── github.com/davecgh/go-spew@v1.1.1
  │    ├── github.com/pmezard/go-difflib@v1.0.0
  │    ├── github.com/stretchr/objx@v0.4.0 (go1.12) => [v0.5.0]
- │    │    └── ...
- │    └── gopkg.in/yaml.v3@v3.0.1
- │         └── ...
- ├── github.com/tinygo-org/cbgo@v0.0.4 (go1.14)
+ │    │    └── 2 more ...
+ │    └── gopkg.in/yaml.v3@v3.0.1, see <3> for 1 children (branch 'gobot.io/x/gobot' level 1)
+ ├── <12> github.com/tinygo-org/cbgo@v0.0.4 (go1.14)
  │    └── github.com/sirupsen/logrus@v1.5.0 => [v1.9.0] (go1.13)
- │         └── ...
- ├── github.com/urfave/cli@v1.22.10 (go1.11) => [v1.22.12]
+ │         └── 5 more ...
+ ├── github.com/urfave/cli@v1.22.10 (go1.11) => [v1.22.13]
  │    ├── github.com/BurntSushi/toml@v0.3.1 => [v1.2.1]
  │    ├── github.com/cpuguy83/go-md2man/v2@v2.0.0-20190314233015-f79a8a8ca69d => [v2.0.2] (go1.11)
- │    │    └── ...
- │    └── gopkg.in/yaml.v2@v2.2.2 => [v2.4.0]
- │         └── ...
- ├── github.com/veandco/go-sdl2@v0.4.25 (go1.15) => [v0.4.34]
+ │    │    └── 3 more ...
+ │    └── <4> gopkg.in/yaml.v2@v2.2.2 => [v2.4.0]
+ │         └── 1 more ...
+ ├── github.com/veandco/go-sdl2@v0.4.25 (go1.15) => [v0.4.35]
  ├── github.com/warthog618/gpiod@v0.8.0 (go1.17) => [v0.8.1]
  │    ├── github.com/pilebones/go-udev@v0.0.0-20180820235104-043677e09b13 => [v0.9.0]
  │    ├── github.com/spf13/cobra@v0.0.5 (go1.12) => [v1.7.0]
  │    ├── github.com/spf13/pflag@v1.0.5 (go1.12)
  │    ├── github.com/stretchr/testify@v1.4.0 => [v1.8.2]
  │    ├── github.com/warthog618/config@v0.4.1 (go1.11) => [v0.5.1]
- │    ├── golang.org/x/sys@v0.0.0-20200223170610-d5e6a3e2c0ae => [v0.7.0]
+ │    ├── golang.org/x/sys@v0.0.0-20200223170610-d5e6a3e2c0ae => [v0.8.0]
  │    ├── gopkg.in/check.v1@v1.0.0-20190902080502-41f04d3bba15 => [v1.0.0-20201130134442-10cb98267c6c]
  │    ├── github.com/davecgh/go-spew@v1.1.1
  │    ├── github.com/fsnotify/fsnotify@v1.4.7 => [v1.6.0]
  │    ├── github.com/inconshreveable/mousetrap@v1.0.0 => [v1.1.0]
  │    ├── github.com/pkg/errors@v0.8.1 => [v0.9.1]
  │    ├── github.com/pmezard/go-difflib@v1.0.0
- │    └── gopkg.in/yaml.v2@v2.2.2 => [v2.4.0]
- │         └── ...
+ │    └── gopkg.in/yaml.v2@v2.2.2 => [v2.4.0], see <4> for 1 children (branch 'github.com/urfave/cli@v1.22.10' level 2)
  ├── go.bug.st/serial@v1.4.0 (go1.17) => [v1.5.0]
  │    ├── github.com/creack/goselect@v0.1.2 (go1.13)
- │    ├── github.com/stretchr/testify@v1.7.0 => [v1.8.2]
- │    │    └── ...
- │    ├── golang.org/x/sys@v0.0.0-20210823070655-63515b42dcdf => [v0.7.0]
+ │    ├── github.com/stretchr/testify@v1.7.0 => [v1.8.2], see <5> for 1 children (branch 'github.com/sirupsen/logrus@v1.9.0' level 2)
+ │    ├── golang.org/x/sys@v0.0.0-20210823070655-63515b42dcdf => [v0.8.0]
  │    ├── github.com/davecgh/go-spew@v1.1.0 => [v1.1.1]
  │    ├── github.com/pmezard/go-difflib@v1.0.0
  │    └── gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c => [v3.0.1]
- │         └── ...
+ │         └── 1 more ...
  ├── gocv.io/x/gocv@v0.31.0 (go1.13) => [v0.32.1]
  │    ├── github.com/hybridgroup/mjpeg@v0.0.0-20140228234708-4680f319790e
  │    └── github.com/pascaldekloe/goe@v0.1.0 => [v0.1.1]
- ├── golang.org/x/crypto@v0.1.0 (go1.17) => [v0.8.0]
- │    ├── golang.org/x/net@v0.1.0 (go1.17) => [v0.9.0]
- │    │    └── ...
- │    ├── golang.org/x/sys@v0.1.0 (go1.17) => [v0.7.0]
- │    ├── golang.org/x/term@v0.1.0 (go1.17) => [v0.7.0]
+ ├── golang.org/x/crypto@v0.1.0 (go1.17) => [v0.9.0]
+ │    ├── golang.org/x/net@v0.1.0 (go1.17) => [v0.10.0], see <6> for 3 children (branch 'gobot.io/x/gobot' level 1)
+ │    ├── golang.org/x/sys@v0.1.0 (go1.17) => [v0.8.0]
+ │    ├── golang.org/x/term@v0.1.0 (go1.17) => [v0.8.0]
  │    └── golang.org/x/text@v0.4.0 (go1.17) => [v0.9.0]
- ├── golang.org/x/net@v0.1.0 (go1.17) => [v0.9.0]
- │    ├── golang.org/x/sys@v0.1.0 (go1.17) => [v0.7.0]
- │    ├── golang.org/x/term@v0.1.0 (go1.17) => [v0.7.0]
+ ├── <6> golang.org/x/net@v0.1.0 (go1.17) => [v0.10.0]
+ │    ├── golang.org/x/sys@v0.1.0 (go1.17) => [v0.8.0]
+ │    ├── golang.org/x/term@v0.1.0 (go1.17) => [v0.8.0]
  │    └── golang.org/x/text@v0.4.0 (go1.17) => [v0.9.0]
- ├── golang.org/x/sync@v0.1.0
- ├── golang.org/x/sys@v0.1.0 (go1.17) => [v0.7.0]
+ ├── golang.org/x/sync@v0.1.0 => [v0.2.0]
+ ├── golang.org/x/sys@v0.1.0 (go1.17) => [v0.8.0]
  ├── google.golang.org/protobuf@v1.28.1 (go1.11) => [v1.30.0]
- │    ├── github.com/golang/protobuf@v1.5.0 (go1.9) => [v1.5.3]
- │    │    └── ...
- │    └── github.com/google/go-cmp@v0.5.5 (go1.8) => [v0.5.9]
- │         └── ...
- ├── gopkg.in/yaml.v3@v3.0.1
+ │    ├── github.com/golang/protobuf@v1.5.0 (go1.9) => [v1.5.3], see <7> for 2 children (branch 'gobot.io/x/gobot' level 1)
+ │    └── github.com/google/go-cmp@v0.5.5 (go1.8) => [v0.5.9], see <8> for 1 children (branch 'github.com/golang/protobuf@v1.5.0' level 2)
+ ├── <3> gopkg.in/yaml.v3@v3.0.1
  │    └── gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405 => [v1.0.0-20201130134442-10cb98267c6c]
- ├── periph.io/x/conn/v3@v3.6.10 (go1.13) => [v3.7.0]
+ ├── <9> periph.io/x/conn/v3@v3.6.10 (go1.13) => [v3.7.0]
  │    └── github.com/jonboulle/clockwork@v0.2.2 (go1.13) => [v0.4.0]
- ├── periph.io/x/host/v3@v3.7.2 (go1.13) => [v3.8.0]
- │    ├── periph.io/x/conn/v3@v3.6.10 (go1.13) => [v3.7.0]
- │    │    └── ...
+ ├── periph.io/x/host/v3@v3.7.2 (go1.13) => [v3.8.2]
+ │    ├── periph.io/x/conn/v3@v3.6.10 (go1.13) => [v3.7.0], see <9> for 1 children (branch 'gobot.io/x/gobot' level 1)
  │    └── periph.io/x/d2xx@v0.0.4 (go1.13) => [v0.1.0]
  └── tinygo.org/x/bluetooth@v0.6.0 (go1.15)
-      ├── github.com/go-ole/go-ole@v1.2.6 (go1.12)
-      │    └── ...
+      ├── github.com/go-ole/go-ole@v1.2.6 (go1.12), see <2> for 1 children (branch 'gobot.io/x/gobot' level 1)
       ├── github.com/godbus/dbus/v5@v5.0.3 => [v5.1.0] (go1.12)
-      ├── github.com/muka/go-bluetooth@v0.0.0-20220830075246-0746e3a1ea53 (go1.14) => [v0.0.0-20221213043340-85dc80edc4e1]
-      │    └── ...
-      ├── github.com/saltosystems/winrt-go@v0.0.0-20220826130236-ddc8202da421 => [v0.0.0-20230124093143-967a889c6c8f]
-      │    └── ...
-      ├── github.com/sirupsen/logrus@v1.9.0 (go1.13)
-      │    └── ...
-      ├── github.com/tinygo-org/cbgo@v0.0.4 (go1.14)
-      │    └── ...
-      ├── golang.org/x/crypto@v0.0.0-20210921155107-089bfa567519 => [v0.8.0]
-      │    └── ...
-      ├── golang.org/x/sys@v0.0.0-20220829200755-d48e67d00261 => [v0.7.0]
+      ├── github.com/muka/go-bluetooth@v0.0.0-20220830075246-0746e3a1ea53 (go1.14) => [v0.0.0-20221213043340-85dc80edc4e1], see <10> for 10 children (branch 'gobot.io/x/gobot' level 1)
+      ├── github.com/saltosystems/winrt-go@v0.0.0-20220826130236-ddc8202da421 => [v0.0.0-20230510070731-e096b9afa761]
+      │    └── 13 more ...
+      ├── github.com/sirupsen/logrus@v1.9.0 (go1.13), see <11> for 3 children (branch 'gobot.io/x/gobot' level 1)
+      ├── github.com/tinygo-org/cbgo@v0.0.4 (go1.14), see <12> for 1 children (branch 'gobot.io/x/gobot' level 1)
+      ├── golang.org/x/crypto@v0.0.0-20210921155107-089bfa567519 => [v0.9.0]
+      │    └── 4 more ...
+      ├── golang.org/x/sys@v0.0.0-20220829200755-d48e67d00261 => [v0.8.0]
       ├── tinygo.org/x/drivers@v0.23.0 (go1.15) => [v0.24.0]
-      │    └── ...
+      │    └── 6 more ...
       └── tinygo.org/x/tinyterm@v0.1.0 (go1.15) => [v0.2.0]
-           └── ...
+           └── 4 more ...
 ```
 
 ## Variant: file for dependency graph

--- a/README.md
+++ b/README.md
@@ -243,3 +243,17 @@ cd into the package root folder (contains go.mod) and run:
 Relative paths can be used also.
 
 `deptree -graph=data/graphfile.txt -upgrade=data/upgradefile.txt`
+
+## Duplicate occurrence of children
+
+More than one occurrence of an item at different levels of the tree is possible. This occurs very likely for projects
+with many dependencies (count of imports in go.mod file). `deptree` handles this in the following way to avoid duplicate
+information, waste of processing time and possibly circular dependencies:
+
+* first occurrence of the child will be processed and shown with all sub-children
+* already processed children will be filtered by default
+* the parameter "-a" will show a link to the first processed item (do not filter the line completely)
+* the parameter "-f" forces to process and show each child with all sub-children (stopped at the given depth level)
+
+> The option "-f" can lead to hang due to circular dependencies or great amount of work. If this setting is really
+> needed and you note a very long delay, try to set the depth parameter "-d" as minimal as possible.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -82,8 +82,9 @@ func getUpgradeContent(upgradeFile string, verbose verbose.Verbose) []byte {
 }
 
 // getGraphFile gets the file handle to access content from STDIN or graph file
-func getGraphFile(graphFile string, verbose verbose.Verbose) (file *os.File) {
+func getGraphFile(graphFile string, verbose verbose.Verbose) *os.File {
 	var err error
+	var file *os.File
 	if len(graphFile) == 0 {
 		file = os.Stdin
 	} else {
@@ -97,5 +98,5 @@ func getGraphFile(graphFile string, verbose verbose.Verbose) (file *os.File) {
 		}
 	}
 	verbose.Log1f("graph content retrieved")
-	return
+	return file
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,49 +12,58 @@ import (
 
 	"github.com/vc60er/deptree/internal/moduleinfo"
 	"github.com/vc60er/deptree/internal/tree"
+	"github.com/vc60er/deptree/internal/verbose"
 )
 
 // Execute starts the main code
 // - get all upgradable modules: "go list -u -m -json all" and only those with newer version
 // - filter list of "go mod graph" (all children with parent) to all upradeable children
 // - print all parents needs to upgrade for usage of its (direct) upgradable children
+// - colored output
 func Execute() {
 	// TODO:
-	// - colored output
 	// - check go version
-	showAll := flag.Bool("a", false, "show all dependencies, not only with upgrade")
+	showAll := flag.Bool("a", false, "show all dependencies, also without upgrade and point out duplicated children")
 	colored := flag.Bool("c", false, "upgrade candidates will be marked yellow")
 	depth := flag.Int("d", 3, "max depth of dependencies")
+	showDroppedChild := flag.Bool("f", false, "force show of each occurrence of a child branch in tree (can cause hang)")
 	visualizeTrimmed := flag.Bool("t", false, "visualize trimmed tree by '└─...'")
 	printJSON := flag.Bool("json", false, "print JSON instead of tree")
 	graphFile := flag.String("graph", "", "path to file created e.g. by 'go mod graph > grapphfile.txt'")
 	upgradeFile := flag.String("upgrade", "", "path to file created e.g. by 'go list -u -m -json all > upgradefile.txt'")
+	verboseLevel := flag.Int("v", 0, "be more verbose")
 	flag.Parse()
 
-	info := moduleinfo.NewInfo()
-	info.Fill(getUpgradeContent(*upgradeFile))
+	v := verbose.NewVerbose(*verboseLevel)
 
-	tree := tree.NewTree(*depth, *visualizeTrimmed, *showAll, *colored, *info)
-	file := getGraphFile(*graphFile)
+	info := moduleinfo.NewInfo(v)
+	info.Fill(getUpgradeContent(*upgradeFile, v))
+	v.Log1f("fill with upgrade content done")
+
+	tree := tree.NewTree(v, *depth, *showDroppedChild, *visualizeTrimmed, *showAll, *colored, *info)
+	file := getGraphFile(*graphFile, v)
 	defer file.Close()
 	tree.Fill(file)
+	v.Log1f("fill with graph content done")
 
 	info.Adjust()
+	v.Log1f("content adjusted")
 
 	tree.Print(*printJSON)
+	v.Log1f("finished")
 }
 
 // getUpgradeContent gets the JSON content from go list call or upgrade file
-func getUpgradeContent(upgradeFile string) []byte {
-	// get all modules including upgrade versions
+func getUpgradeContent(upgradeFile string, verbose verbose.Verbose) []byte {
 	var goListCallJSONContent []byte
 	if len(upgradeFile) == 0 {
+		fmt.Println("call 'go list -u -m -json all', be patient...")
 		var outbuf, errbuf bytes.Buffer
 		cmd := exec.Command("go", "list", "-u", "-m", "-json", "all")
 		cmd.Stdout = &outbuf
 		cmd.Stderr = &errbuf
 		if err := cmd.Run(); err != nil {
-			log.Fatal(fmt.Sprintf("%v, %s", err, errbuf.String()))
+			log.Fatalf("%v, %s", err, errbuf.String())
 		}
 		goListCallJSONContent = outbuf.Bytes()
 	} else {
@@ -68,11 +77,12 @@ func getUpgradeContent(upgradeFile string) []byte {
 		}
 	}
 
+	verbose.Log1f("upgrade content retrieved")
 	return goListCallJSONContent
 }
 
 // getGraphFile gets the file handle to access content from STDIN or graph file
-func getGraphFile(graphFile string) (file *os.File) {
+func getGraphFile(graphFile string, verbose verbose.Verbose) (file *os.File) {
 	var err error
 	if len(graphFile) == 0 {
 		file = os.Stdin
@@ -86,5 +96,6 @@ func getGraphFile(graphFile string) (file *os.File) {
 			log.Fatal(err)
 		}
 	}
+	verbose.Log1f("graph content retrieved")
 	return
 }

--- a/internal/moduleinfo/moduleinfo.go
+++ b/internal/moduleinfo/moduleinfo.go
@@ -25,7 +25,7 @@ func NewInfo(verbose verbose.Verbose) *Info {
 
 // Fill adds given content to the modules map.
 func (i *Info) Fill(goListCallJSONContent []byte) {
-	// add missing paranthesis
+	// add missing parenthesis
 	goListCallJSONContent = append(append([]byte{'['}, goListCallJSONContent...), ']')
 	// fix missing commas
 	goListCallJSONContent = []byte(strings.ReplaceAll(string(goListCallJSONContent), "}\n{", "},{"))
@@ -48,7 +48,8 @@ func (i *Info) GetModuleAddIfEmpty(name string) *Module {
 	}
 	splitName := strings.Split(name, "@")
 	m := Module{Path: splitName[0]}
-	if len(splitName) == 2 {
+	const lenWithVersion = 2
+	if len(splitName) == lenWithVersion {
 		m.Version = splitName[1]
 	}
 	i.modules[name] = &m

--- a/internal/moduleinfo/moduleinfo.go
+++ b/internal/moduleinfo/moduleinfo.go
@@ -4,16 +4,20 @@ import (
 	"encoding/json"
 	"log"
 	"strings"
+
+	"github.com/vc60er/deptree/internal/verbose"
 )
 
 // Info stores all attributes for retrieve module information
 type Info struct {
+	verbose verbose.Verbose
 	modules map[string]*Module
 }
 
 // NewInfo creates a new instance
-func NewInfo() *Info {
+func NewInfo(verbose verbose.Verbose) *Info {
 	i := Info{
+		verbose: verbose,
 		modules: make(map[string]*Module),
 	}
 	return &i
@@ -34,8 +38,7 @@ func (i *Info) Fill(goListCallJSONContent []byte) {
 	for idx, module := range moduleList {
 		i.modules[module.Name()] = &moduleList[idx]
 	}
-
-	return
+	i.verbose.Log1f("%d modules collected", len(i.modules))
 }
 
 // GetModuleAddIfEmpty returns a module if exist, otherwise add it to the map before return
@@ -54,13 +57,17 @@ func (i *Info) GetModuleAddIfEmpty(name string) *Module {
 
 // Adjust modules after all is parsed
 func (i *Info) Adjust() {
+	var cnt int
 	for _, mod1 := range i.modules {
 		for _, mod2 := range i.modules {
 			if mod1.Path == mod2.Path && mod1.Version != mod2.Version {
+				cnt++
 				mod1.related = append(mod1.related, mod2)
 			}
 		}
 	}
+	i.verbose.Log1f("%d adjustments done", cnt)
+	i.verbose.Log1f("%d modules after adjust", len(i.modules))
 }
 
 // Print the module of the given path for debugging purposes

--- a/internal/moduleinfo/moduleinfo_test.go
+++ b/internal/moduleinfo/moduleinfo_test.go
@@ -8,13 +8,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vc60er/deptree/internal/verbose"
 )
 
 func TestNewInfo(t *testing.T) {
 	// arrange
 	assert := assert.New(t)
+	v := verbose.Verbose{}
 	// act
-	got := NewInfo()
+	got := NewInfo(v)
 	// assert
 	assert.NotNil(got.modules)
 }

--- a/internal/moduleinfo/moduleinfo_test.go
+++ b/internal/moduleinfo/moduleinfo_test.go
@@ -95,13 +95,14 @@ func TestAdjust(t *testing.T) {
 	assert.Equal(0, len(testModule3.related))
 }
 
-func getContent(upgradeFile string) (goListCallJSONContent []byte) {
+func getContent(upgradeFile string) []byte {
 	var err error
 	if upgradeFile, err = filepath.Abs(upgradeFile); err != nil {
 		log.Fatal(err)
 	}
+	var goListCallJSONContent []byte
 	if goListCallJSONContent, err = ioutil.ReadFile(upgradeFile); err != nil {
 		log.Fatal(err)
 	}
-	return
+	return goListCallJSONContent
 }

--- a/internal/moduleinfo/version.go
+++ b/internal/moduleinfo/version.go
@@ -7,7 +7,6 @@ import (
 )
 
 type version struct {
-	vStr     string
 	major    int
 	minor    int
 	patch    int

--- a/internal/tree/route.go
+++ b/internal/tree/route.go
@@ -3,11 +3,14 @@ package tree
 import (
 	"fmt"
 	"strings"
+
+	"github.com/vc60er/deptree/internal/verbose"
 )
 
 const (
-	depthMarker   = "..."
-	upgradeMarker = "["
+	depthMarker            = "..."
+	upgradeMarker          = "["
+	alreadyProcessedMarker = "see <"
 )
 
 const (
@@ -21,28 +24,37 @@ const (
 	colorWhite  = "\033[37m"
 )
 
-type routeTreeLine struct {
-	color   string
-	route   string
-	content string
-	view    bool
-	parent  *routeTreeLine
-}
-
 type routeTreeLines []*routeTreeLine
 
-type routeTree struct {
-	maxDepth int
-	lines    *routeTreeLines
+type routeTreeLine struct {
+	color             string
+	route             string
+	level             int
+	link              string
+	name              string
+	additionalContent string
+	view              bool
+	parent            *routeTreeLine
+	children          routeTreeLines
 }
 
-var colorDefinition = map[string]string{upgradeMarker: colorYellow}
+type routeTree struct {
+	verbose          verbose.Verbose
+	maxDepth         int
+	showDroppedChild bool
+	lines            *routeTreeLines
+	mostChildren     treeItem
+}
+
+var colorDefinition = map[string]string{upgradeMarker: colorYellow, alreadyProcessedMarker: colorCyan}
 
 // printRoute prints out the tree as route to the console
 func (t *tree) printRoute() {
 	rt := routeTree{
-		maxDepth: t.depth,
-		lines:    &routeTreeLines{},
+		verbose:          t.verbose,
+		maxDepth:         t.depth,
+		showDroppedChild: t.showDroppedChild,
+		lines:            &routeTreeLines{},
 	}
 	if t.visualizeTrimmed {
 		// to prepare the route for "..." lines, we need one level more
@@ -50,113 +62,173 @@ func (t *tree) printRoute() {
 	}
 
 	// evaluate data and apply filters
-	rt.processItem("", *t.rootItem, nil)
+	rt.processItem(*t.rootItem, nil)
+	t.verbose.Log1f("%d tree items processed", len(*rt.lines))
+	t.verbose.Log1f("item with most children %s (%d)", rt.mostChildren.module.Name(), len(rt.mostChildren.children))
 	filtered := rt.lines.applyDepthFilter(t.depth, t.visualizeTrimmed)
+	if filtered > 0 {
+		rt.lines = rt.lines.cleanInvisible()
+	}
 	if !t.showAll {
-		filtered = filtered + rt.lines.applyUpgradableFilter(t.visualizeTrimmed)
+		f := rt.lines.applyUpgradableFilter(t.visualizeTrimmed)
+		if f > 0 {
+			rt.lines = rt.lines.cleanInvisible()
+			filtered = filtered + f
+		}
+	}
+	var duplicateChildTrees int
+	if !t.showDroppedChild {
+		f, l := rt.lines.applyAlreadyProcessedFilter(t.showAll)
+		duplicateChildTrees = l
+		if f > 0 {
+			rt.lines = rt.lines.cleanInvisible()
+			filtered = filtered + f
+		}
 	}
 	if t.colored {
 		rt.lines.applyColors()
 	}
-	// ensure at least root is shown
+
+	// prepare output (all invisible lines are already removed from list)
 	if len(*rt.lines) > 0 {
-		(*rt.lines)[0].view = true
+		firstLine := (*rt.lines)[0]
+		firstLine.view = true // ensure at least root is shown
+		createRoutes(firstLine, "")
 	}
 
-	// prepare output
 	cReset := ""
 	if t.colored {
 		cReset = colorReset
 	}
+
 	var toPrint []string
 	for _, l := range *rt.lines {
-		if l.view {
-			toPrint = append(toPrint, fmt.Sprintf("%s%s%s%s", l.route, l.color, l.content, cReset))
-		}
+		toPrint = append(toPrint, fmt.Sprintf("%s%s%s%s%s%s", l.route, l.link, l.color, l.name, l.additionalContent, cReset))
 	}
 
-	fmt.Printf("dependency tree with depth %d for package: %s", t.depth, t.rootItem.module.Name())
+	txt := fmt.Sprintf("dependency tree with depth %d for package: %s", t.depth, t.rootItem.module.Name())
 	if filtered > 0 {
-		fmt.Printf(", least %d trimmed item(s)", filtered)
+		txt = fmt.Sprintf("%s, least %d trimmed item(s)", txt, filtered)
 	}
-	var bracketText []string
+	fmt.Println(txt)
+
 	if !t.visualizeTrimmed {
-		bracketText = append(bracketText, "no visualization for trimmed tree")
+		fmt.Println("* no visualization for trimmed tree (-t not set)")
 	}
 	if !t.showAll {
-		bracketText = append(bracketText, "only upgradable items with parents")
+		fmt.Println("* only upgradable items with parents are shown (-a not set)")
 	}
-	if len(bracketText) > 0 {
-		fmt.Printf(" (%s)", strings.Join(bracketText, ", "))
+	if !t.showDroppedChild {
+		if !t.showAll {
+			fmt.Println("* duplicate children not shown (-a not set)")
+		} else {
+			fmt.Println("* tree of duplicate children not drawn (-f not set)")
+		}
 	}
-	fmt.Printf("\n\n")
+	if duplicateChildTrees > 0 {
+		fmt.Printf("* %d duplicate child trees replaced by links\n", duplicateChildTrees)
+	}
+	fmt.Println("")
 	fmt.Println(strings.Join(toPrint, "\n"))
 }
 
 // processItem add lines with route sign etc. starting at the given item
-func (rt *routeTree) processItem(route string, item treeItem, parentLine *routeTreeLine) int {
-	if (len([]rune(string(route)))+1)/5 > rt.maxDepth {
-		return -1
+func (rt *routeTree) processItem(item treeItem, parentLine *routeTreeLine) {
+	var branchName string
+	var level int
+	if parentLine != nil {
+		branchName = parentLine.name
+		level = parentLine.level + 1
 	}
-	line := rt.createAndAddLine(route, item, parentLine)
+	if level > rt.maxDepth {
+		rt.verbose.Log3f("maxDepth reached for %s", item.module.Name())
+		return
+	}
 
-	if len(item.children) > 0 {
-		childPath := route
-		childPath = strings.Replace(childPath, "└", " ", -1)
-		childPath = strings.Replace(childPath, "├", "│", -1)
-		childPath = strings.Replace(childPath, "─", " ", -1)
-		childPath = strings.Replace(childPath, "┌", "│", -1)
+	name := item.module.Name()
+	childLen := len(item.children)
+	rt.verbose.Log2f("process branch '%s', level %d, item %s, children: %d",
+		branchName, level, name, childLen)
 
-		childLen := len(item.children)
-		for i, child := range item.children {
-			corner := ""
-			if i == childLen-1 {
-				corner = childPath + " └── "
-			} else {
-				corner = childPath + " ├── "
-			}
-			if rt.processItem(corner, *child, line) == -1 {
-				break
+	line := rt.createAndAddLine(level, item, parentLine)
+
+	if childLen > 0 {
+		if len(rt.mostChildren.children) < childLen {
+			rt.mostChildren = item
+		}
+		// we only collect children on new branch, if found at a higher position (lower level)
+		if !rt.showDroppedChild {
+			ho := rt.lines.highestOccurrence(name)
+			if ho.branch() != branchName && ho.level <= level {
+				rt.verbose.Log2f("%d children dropped at branch '%s' level %d for %s",
+					childLen, branchName, level, item.module.Name())
+				return
 			}
 		}
+		for _, child := range item.children {
+			rt.processItem(*child, line)
+		}
 	}
-
-	return 0
 }
 
 // createAndAddLine creates the line object with route sign etc. and add it to the lines list
-func (rt *routeTree) createAndAddLine(route string, item treeItem, parentLine *routeTreeLine) *routeTreeLine {
-	lineContent := item.module.Name()
+func (rt *routeTree) createAndAddLine(level int, item treeItem, parentLine *routeTreeLine) *routeTreeLine {
+	var addContent string
+
 	if len(item.module.GoVersion) > 0 {
-		lineContent = fmt.Sprintf("%s (go%s)", lineContent, item.module.GoVersion)
+		addContent = fmt.Sprintf(" (go%s)", item.module.GoVersion)
 	}
+
 	updateModule := item.module.GetUpdateModule()
 	if updateModule != nil {
-		lineContent = fmt.Sprintf("%s => %s%s]", lineContent, upgradeMarker, updateModule.Version)
+		addContent = fmt.Sprintf("%s => %s%s]", addContent, upgradeMarker, updateModule.Version)
 		if len(updateModule.GoVersion) > 0 {
-			lineContent = fmt.Sprintf("%s (go%s)", lineContent, updateModule.GoVersion)
+			addContent = fmt.Sprintf("%s (go%s)", addContent, updateModule.GoVersion)
 		}
 	}
-	return rt.lines.add(route, lineContent, parentLine)
+
+	return rt.lines.add(level, item.module.Name(), addContent, parentLine)
+}
+
+func (ls *routeTreeLines) highestOccurrence(name string) *routeTreeLine {
+	var highestOccurence *routeTreeLine
+	for _, l := range *ls {
+		if l.name == name && (highestOccurence == nil || highestOccurence.level > l.level) {
+			highestOccurence = l
+		}
+	}
+	return highestOccurence
 }
 
 // add creates a new instance with the given content and add it to the list
-func (ls *routeTreeLines) add(route, content string, parentLine *routeTreeLine) *routeTreeLine {
-	l := &routeTreeLine{route: route, content: content, view: true, parent: parentLine}
-	*ls = append(*ls, l)
-	return l
+func (ls *routeTreeLines) add(level int, name, additionalContent string, parentLine *routeTreeLine) *routeTreeLine {
+	l := routeTreeLine{
+		level:             level,
+		name:              name,
+		additionalContent: additionalContent,
+		view:              true,
+		parent:            parentLine,
+	}
+	*ls = append(*ls, &l)
+	if parentLine != nil {
+		parentLine.children = append(parentLine.children, &l)
+	}
+	return &l
 }
 
 // applyDepthFilter mark lines to show on later print to console according to given depth
 func (ls *routeTreeLines) applyDepthFilter(printDepth int, visualizeTrimmed bool) (countFiltered int) {
-	skipNext := false
+	var skipNext bool
 	for _, l := range *ls {
-		if (len([]rune(string(l.route)))+3)/5 > printDepth {
+		if l.level > printDepth {
 			countFiltered++
 			if !skipNext {
 				if visualizeTrimmed {
-					l.route = strings.Replace(l.route, "├", "└", -1)
-					l.content = depthMarker
+					l.name = ""
+					if l.parent != nil {
+						l.name = fmt.Sprintf("%d more ", len(l.parent.children))
+					}
+					l.additionalContent = depthMarker
 				} else {
 					l.view = false
 				}
@@ -179,14 +251,14 @@ func (ls *routeTreeLines) applyUpgradableFilter(visualizeTrimmed bool) (countFil
 		if !l.view {
 			continue
 		}
-		if visualizeTrimmed && checkNextForDots && strings.Contains(l.content, depthMarker) {
+		if visualizeTrimmed && checkNextForDots && strings.Contains(l.additionalContent, depthMarker) {
 			// keep this dots active, but not the next
 			checkNextForDots = false
 			continue
 		}
 
 		// set all not upgradable to not viewable
-		if !strings.Contains(l.content, upgradeMarker) {
+		if !strings.Contains(l.additionalContent, upgradeMarker) {
 			if l.view {
 				l.view = false
 				countFiltered++
@@ -213,16 +285,170 @@ func (ls *routeTreeLines) applyUpgradableFilter(visualizeTrimmed bool) (countFil
 	return
 }
 
+// applyAlreadyProcessedFilter set lines which points to already processed children to invisible, except showAll is set,
+// for showAll=true already processed children will be linked to the first occurrence with lowest level, which means:
+// * this child get a link and its tree will be print completely
+// * further occurrences of child tree will be linked to the first (with note the parent branch, to find quickly)
+func (ls *routeTreeLines) applyAlreadyProcessedFilter(showAll bool) (countFiltered int, createdLinks int) {
+	// if not showAll, set all occurrences to invisible, except the highest and return
+	if !showAll {
+		for _, l := range *ls {
+			// not viewables keep untouched and at root level all items occur the first time
+			if !l.view || l.parent == nil {
+				continue
+			}
+
+			all := ls.allOccurrences(l.name)
+			if len(all) <= 1 {
+				// there is only one occurrence (the first), so keep it as is
+				continue
+			}
+
+			highestOccurrence := all.highestOccurrence(l.name)
+			if highestOccurrence.branch() != l.parent.name {
+				// this is not the highest occurrence, set children to invisible
+				for _, c := range l.children {
+					if c.view {
+						c.view = false
+						countFiltered++
+					}
+				}
+				continue
+			}
+		}
+		return countFiltered, 0
+	}
+
+	// if all occurrences should be shown (showAll==true) and if there are visible children, we need some links
+	linkNumbers := make(map[*routeTreeLine]int)
+	for _, l := range *ls {
+		// not viewables keep untouched and at root level all items occur the first time
+		if !l.view || l.parent == nil {
+			continue
+		}
+
+		// same items on same or different branch can lead to complex/indirect circular dependencies, so we don't draw it
+		// each time, but replace it with a link
+		all := ls.allOccurrences(l.name)
+		if len(all) <= 1 {
+			// there is only one occurrence (the first), so keep it as is
+			continue
+		}
+
+		highestOccurrence := all.highestOccurrence(l.name)
+
+		countVisibleChildren := highestOccurrence.children.countVisible()
+		if countVisibleChildren <= 0 {
+			// there is nothing to do if no visible children exist at first occurrence
+			continue
+		}
+
+		firstOccurrenceBranch := highestOccurrence.branch()
+		if firstOccurrenceBranch != l.parent.name {
+			// this is not the first occurrence, so we need a link for the line content
+			linkNumber, ok := linkNumbers[highestOccurrence]
+			if !ok {
+				// this is the first link request, so we create a new link
+				linkNumber = len(linkNumbers) + 1
+				linkNumbers[highestOccurrence] = linkNumber
+				highestOccurrence.link = fmt.Sprintf("<%d> ", linkNumber)
+			}
+			l.additionalContent = fmt.Sprintf("%s, see <%d> for %d children (branch '%s' level %d)",
+				l.additionalContent, linkNumber, countVisibleChildren, firstOccurrenceBranch, highestOccurrence.level)
+			// afterwards all children will be switched off
+			for _, c := range l.children {
+				if c.view {
+					c.view = false
+					countFiltered++
+				}
+			}
+		}
+	}
+	return countFiltered, len(linkNumbers)
+}
+
+func (ls *routeTreeLines) allOccurrences(name string) routeTreeLines {
+	var occurrences []*routeTreeLine
+	for _, l := range *ls {
+		if l.name == name {
+			occurrences = append(occurrences, l)
+		}
+	}
+	return occurrences
+}
+
+func (ls *routeTreeLines) countVisible() int {
+	var count int
+	for _, l := range *ls {
+		if l.view {
+			count++
+		}
+	}
+	return count
+}
+
+func (ls *routeTreeLines) cleanInvisible() *routeTreeLines {
+	var newLines routeTreeLines
+	for _, l := range *ls {
+		if l.view {
+			// do not clean children recursive
+			var newChildren routeTreeLines
+			for _, c := range l.children {
+				if c.view {
+					newChildren = append(newChildren, c)
+				}
+			}
+			l.children = newChildren
+			newLines = append(newLines, l)
+		}
+	}
+	return &newLines
+}
+
 // applyColors colorize lines, which contains defined marker
 func (ls *routeTreeLines) applyColors() {
 	for _, l := range *ls {
 		if !l.view {
 			continue
 		}
+		if l.link != "" {
+			l.link = fmt.Sprintf("%s%s%s", colorDefinition[alreadyProcessedMarker], l.link, colorReset)
+		}
 		for marker, color := range colorDefinition {
-			if strings.Contains(l.content, marker) {
+			if strings.Contains(l.additionalContent, marker) {
 				l.color = color
+				if marker == alreadyProcessedMarker {
+					// has precedence over all other colors
+					break
+				}
 			}
+		}
+	}
+}
+
+func (l *routeTreeLine) branch() string {
+	if l.parent == nil {
+		return ""
+	}
+	return l.parent.name
+}
+
+func createRoutes(line *routeTreeLine, route string) {
+	line.route = route
+	childLen := len(line.children)
+	if childLen > 0 {
+		childPath := route
+		childPath = strings.Replace(childPath, "└", " ", -1)
+		childPath = strings.Replace(childPath, "├", "│", -1)
+		childPath = strings.Replace(childPath, "─", " ", -1)
+		for i, child := range line.children {
+			var corner string
+			if i == childLen-1 {
+				corner = childPath + " └── "
+			} else {
+				corner = childPath + " ├── "
+			}
+			createRoutes(child, corner)
 		}
 	}
 }

--- a/internal/tree/route_test.go
+++ b/internal/tree/route_test.go
@@ -1,24 +1,14 @@
 package tree
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_applyDepthFilter(t *testing.T) {
-	r := []string{
-		"",
-		" ├── ",
-		" ├── ",
-		" │    └── ",
-		" ├── ",
-		" │    ├── ",
-		" │    ├── ",
-		" │    │    ├── ",
-		" │    │    │    └── ",
-	}
-	c := []string{
+	n := []string{
 		"parent",
 		"child1",
 		"child2",
@@ -32,20 +22,20 @@ func Test_applyDepthFilter(t *testing.T) {
 
 	var tests = map[string]struct {
 		visualizeTrimmed bool
-		wantL7Route      string
-		wantL7Content    string
+		wantL7Name       string
+		wantL7AddContent string
 		wantL7View       bool
 	}{
 		"visualized": {
 			visualizeTrimmed: true,
-			wantL7Route:      " │    │    └── ",
-			wantL7Content:    depthMarker,
+			wantL7Name:       "1 more ",
+			wantL7AddContent: depthMarker,
 			wantL7View:       true,
 		},
 		"not_visualized": {
 			visualizeTrimmed: false,
-			wantL7Route:      r[7],
-			wantL7Content:    c[7],
+			wantL7Name:       n[7],
+			wantL7AddContent: "",
 			wantL7View:       false,
 		},
 	}
@@ -54,38 +44,36 @@ func Test_applyDepthFilter(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// arrange
 			assert := assert.New(t)
-			l0 := routeTreeLine{route: r[0], content: c[0], view: true}
-			l1 := routeTreeLine{route: r[1], content: c[1], view: true, parent: &l0}
-			l2 := routeTreeLine{route: r[2], content: c[2], view: true, parent: &l0}
-			l3 := routeTreeLine{route: r[3], content: c[3], view: true, parent: &l2}
-			l4 := routeTreeLine{route: r[4], content: c[4], view: true, parent: &l0}
-			l5 := routeTreeLine{route: r[5], content: c[5], view: true, parent: &l4}
-			l6 := routeTreeLine{route: r[6], content: c[6], view: true, parent: &l4}
-			l7 := routeTreeLine{route: r[7], content: c[7], view: true, parent: &l6}
-			l8 := routeTreeLine{route: r[8], content: c[8], view: true, parent: &l7}
+			l0 := routeTreeLine{name: n[0], view: true}
+			l1 := routeTreeLine{name: n[1], view: true, parent: &l0}
+			l2 := routeTreeLine{name: n[2], view: true, parent: &l0}
+			l3 := routeTreeLine{name: n[3], view: true, parent: &l2}
+			l4 := routeTreeLine{name: n[4], view: true, parent: &l0}
+			l5 := routeTreeLine{name: n[5], view: true, parent: &l4}
+			l6 := routeTreeLine{name: n[6], view: true, parent: &l4}
+			l7 := routeTreeLine{name: n[7], view: true, parent: &l6}
+			l8 := routeTreeLine{name: n[8], view: true, parent: &l7}
+			l0.children = routeTreeLines{&l1, &l2, &l4}
+			l2.children = routeTreeLines{&l3}
+			l4.children = routeTreeLines{&l5, &l6}
+			l6.children = routeTreeLines{&l7}
+			l7.children = routeTreeLines{&l8}
 			ls := &routeTreeLines{&l0, &l1, &l2, &l3, &l4, &l5, &l6, &l7, &l8}
+			setLevels(ls)
 			// act
 			got := ls.applyDepthFilter(2, tc.visualizeTrimmed)
 			// assert
 			assert.Equal(2, got)
-			assert.Equal(r[0], l0.route)
-			assert.Equal(r[1], l1.route)
-			assert.Equal(r[2], l2.route)
-			assert.Equal(r[3], l3.route)
-			assert.Equal(r[4], l4.route)
-			assert.Equal(r[5], l5.route)
-			assert.Equal(r[6], l6.route)
-			assert.Equal(tc.wantL7Route, l7.route)
-			assert.Equal(r[8], l8.route)
-			assert.Equal(c[0], l0.content)
-			assert.Equal(c[1], l1.content)
-			assert.Equal(c[2], l2.content)
-			assert.Equal(c[3], l3.content)
-			assert.Equal(c[4], l4.content)
-			assert.Equal(c[5], l5.content)
-			assert.Equal(c[6], l6.content)
-			assert.Equal(tc.wantL7Content, l7.content)
-			assert.Equal(c[8], l8.content)
+			assert.Equal(n[0], l0.name)
+			assert.Equal(n[1], l1.name)
+			assert.Equal(n[2], l2.name)
+			assert.Equal(n[3], l3.name)
+			assert.Equal(n[4], l4.name)
+			assert.Equal(n[5], l5.name)
+			assert.Equal(n[6], l6.name)
+			assert.Equal(tc.wantL7Name, l7.name)
+			assert.Equal(tc.wantL7AddContent, l7.additionalContent)
+			assert.Equal(n[8], l8.name)
 			assert.True(l0.view)
 			assert.True(l1.view)
 			assert.True(l2.view)
@@ -102,13 +90,13 @@ func Test_applyDepthFilter(t *testing.T) {
 func Test_applyUpgradableFilter(t *testing.T) {
 	// arrange
 	assert := assert.New(t)
-	invisible := routeTreeLine{content: "invisible"}
-	parentOfVisible := routeTreeLine{content: "parent_of_visible", view: true} // parents of visible children are still visible
-	visible := routeTreeLine{content: "visible", view: true, parent: &parentOfVisible}
-	upgradeInvisible := routeTreeLine{content: "upgrade_invisible [v1.2.3]", view: false}
-	parentOfUpgradable := routeTreeLine{content: "parent_of_upgrade", view: true} // parents of visible children are still visible
-	upgradeVisible := routeTreeLine{content: "upgrade_visible [v3.2.1]", view: true, parent: &parentOfUpgradable}
-	dotsAfterUpgrade := routeTreeLine{content: depthMarker, view: true, parent: &upgradeVisible}
+	invisible := routeTreeLine{name: "invisible"}
+	parentOfVisible := routeTreeLine{name: "parent_of_visible", view: true} // parents of visible children are still visible
+	visible := routeTreeLine{name: "visible", view: true, parent: &parentOfVisible}
+	upgradeInvisible := routeTreeLine{name: "upgrade_invisible", additionalContent: " [v1.2.3]", view: false}
+	parentOfUpgradable := routeTreeLine{name: "parent_of_upgrade", view: true} // parents of visible children are still visible
+	upgradeVisible := routeTreeLine{name: "upgrade_visible", additionalContent: " [v3.2.1]", view: true, parent: &parentOfUpgradable}
+	dotsAfterUpgrade := routeTreeLine{name: "", additionalContent: depthMarker, view: true, parent: &upgradeVisible}
 	ls := &routeTreeLines{
 		&invisible,
 		&parentOfVisible,
@@ -131,17 +119,300 @@ func Test_applyUpgradableFilter(t *testing.T) {
 	assert.Equal(true, dotsAfterUpgrade.view)
 }
 
+func Test_applyAlreadyProcessedFilter(t *testing.T) {
+	n := []string{
+		"parent_visible",
+		"child1_invisible",
+		"child2_visible_one_occurrence_child3_child4_child5", // no link because only one occurrence
+		"child3_visible_two_occurrences_no_link",             // no link because no children
+		"child4_visible_two_occurrences_no_link",             // no link because invisible children
+		"child41_invisible",
+		"child5_visible_two_occurrences_with_link", // for link with visible children
+		"child51_visible",
+	}
+
+	var tests = map[string]struct {
+		showAll          bool
+		wantFiltered     int
+		wantLinks        int
+		wantShowL8L9L10  bool
+		wantLinkL11      string
+		wantAddContentL6 string
+	}{
+		"showAll": {
+			showAll:          true,
+			wantFiltered:     1,
+			wantLinks:        1,
+			wantShowL8L9L10:  true,
+			wantLinkL11:      "<1> ",
+			wantAddContentL6: ", see <1> for 1 children (branch 'parent_visible' level 1)",
+		},
+		"not_showAll": {
+			showAll:          false,
+			wantFiltered:     1,
+			wantLinks:        0,
+			wantShowL8L9L10:  false,
+			wantLinkL11:      "",
+			wantAddContentL6: "",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			assert := assert.New(t)
+			l0 := routeTreeLine{name: n[0], view: true}
+			l1 := routeTreeLine{name: n[1], view: false, parent: &l0}
+			l2 := routeTreeLine{name: n[2], view: true, parent: &l0}
+			l3 := routeTreeLine{name: n[3], view: true, parent: &l2}
+			l4 := routeTreeLine{name: n[4], view: true, parent: &l2}
+			l5 := routeTreeLine{name: n[5], view: false, parent: &l4}
+			l6 := routeTreeLine{name: n[6], view: true, parent: &l2}
+			l7 := routeTreeLine{name: n[7], view: true, parent: &l6}
+			l8 := routeTreeLine{name: n[3], view: true, parent: &l0}
+			l9 := routeTreeLine{name: n[4], view: true, parent: &l0}
+			l10 := routeTreeLine{name: n[5], view: false, parent: &l9}
+			l11 := routeTreeLine{name: n[6], view: true, parent: &l0}
+			l12 := routeTreeLine{name: n[7], view: true, parent: &l11}
+			l0.children = routeTreeLines{&l1, &l2, &l8, &l9, &l11}
+			l2.children = routeTreeLines{&l3, &l4, &l6}
+			l4.children = routeTreeLines{&l5}
+			l6.children = routeTreeLines{&l7}
+			l9.children = routeTreeLines{&l10}
+			l11.children = routeTreeLines{&l12}
+			ls := &routeTreeLines{&l0, &l1, &l2, &l3, &l4, &l5, &l6, &l7, &l8, &l9, &l10, &l11, &l12}
+			setLevels(ls)
+			// act
+			gotFiltered, gotLinks := ls.applyAlreadyProcessedFilter(tc.showAll)
+			// assert
+			assert.Equal(tc.wantFiltered, gotFiltered)
+			assert.Equal(tc.wantLinks, gotLinks)
+			assert.True(l0.view)
+			assert.False(l1.view)
+			assert.True(l2.view)
+			assert.True(l3.view)
+			assert.True(l4.view)
+			assert.False(l5.view)
+			assert.True(l6.view)
+			assert.False(l7.view, fmt.Sprintf("L7 contains '%s_%s'", l7.name, l7.additionalContent))
+			assert.True(l8.view)
+			assert.True(l9.view)
+			assert.False(l10.view)
+			assert.True(l11.view)
+			assert.True(l12.view)
+			assert.Equal("", l0.link)
+			assert.Equal("", l1.link)
+			assert.Equal("", l2.link)
+			assert.Equal("", l3.link)
+			assert.Equal("", l4.link)
+			assert.Equal("", l5.link)
+			assert.Equal("", l6.link)
+			assert.Equal("", l7.link)
+			assert.Equal("", l8.link)
+			assert.Equal("", l9.link)
+			assert.Equal("", l10.link)
+			assert.Equal(tc.wantLinkL11, l11.link)
+			assert.Equal("", l12.link)
+			assert.Equal("", l0.additionalContent)
+			assert.Equal("", l1.additionalContent)
+			assert.Equal("", l2.additionalContent)
+			assert.Equal("", l3.additionalContent)
+			assert.Equal("", l4.additionalContent)
+			assert.Equal("", l5.additionalContent)
+			assert.Equal(tc.wantAddContentL6, l6.additionalContent)
+			assert.Equal("", l7.additionalContent)
+			assert.Equal("", l8.additionalContent)
+			assert.Equal("", l9.additionalContent)
+			assert.Equal("", l10.additionalContent)
+			assert.Equal("", l11.additionalContent)
+			assert.Equal("", l12.additionalContent)
+		})
+	}
+}
+
 func Test_applyColors(t *testing.T) {
 	// arrange
 	assert := assert.New(t)
-	invisible := routeTreeLine{content: "invisible"}
-	visible := routeTreeLine{content: "visible", view: true}
-	upgrade := routeTreeLine{content: "upgrade [v1.2.3]", view: true}
-	ls := &routeTreeLines{&invisible, &visible, &upgrade}
+	invisible := routeTreeLine{name: "invisible"}
+	visible := routeTreeLine{name: "visible", view: true}
+	upgrade := routeTreeLine{name: "upgrade", additionalContent: " [v1.2.3]", view: true}
+	linked := routeTreeLine{name: "linked", additionalContent: "see <3>", view: true}
+	ls := &routeTreeLines{&invisible, &visible, &upgrade, &linked}
 	// act
 	ls.applyColors()
 	// assert
 	assert.Equal("", invisible.color)
 	assert.Equal("", visible.color)
 	assert.Equal(colorYellow, upgrade.color)
+	assert.Equal(colorCyan, linked.color)
+}
+
+func Test_cleanInvisible(t *testing.T) {
+	// arrange
+	assert := assert.New(t)
+	l1 := routeTreeLine{name: "to clean"}
+	l2 := routeTreeLine{name: "stay", view: true}
+	l3 := routeTreeLine{name: "child1 to stay", view: true}
+	l4 := routeTreeLine{name: "child2 to clean"}
+	l5 := routeTreeLine{name: "child3 to stay", view: true}
+	l2.children = routeTreeLines{&l3, &l4, &l5}
+	ls := routeTreeLines{&l1, &l2, &l3, &l4, &l5}
+	// act
+	got := ls.cleanInvisible()
+	// assert
+	assert.NotSame(ls, got)
+	assert.Equal(3, len(*got))
+	assert.Equal(&l2, (*got)[0])
+	assert.Equal(&l3, (*got)[1])
+	assert.Equal(&l5, (*got)[2])
+	parent := (*got)[0]
+	assert.Equal(2, len(parent.children))
+	assert.Equal(&l3, parent.children[0])
+	assert.Equal(&l5, parent.children[1])
+}
+
+func Test_createRoutes(t *testing.T) {
+	var tests = map[string]struct {
+		line     routeTreeLine
+		previous string
+		want     []string
+	}{
+		"root_no_child": {
+			line: routeTreeLine{view: true},
+			want: []string{""},
+		},
+		"level1_single_no_child": {
+			line:     routeTreeLine{view: true},
+			previous: " └── ",
+			want: []string{
+				" └── ",
+			},
+		},
+		"level1_more_no_child": {
+			line:     routeTreeLine{view: true},
+			previous: " ├── ",
+			want: []string{
+				" ├── ",
+			},
+		},
+		"root_one_child": {
+			line: routeTreeLine{
+				view: true,
+				children: routeTreeLines{
+					&routeTreeLine{view: true},
+				},
+			},
+			want: []string{
+				"",
+				" └── ",
+			},
+		},
+		"level1_single_one_child": {
+			line: routeTreeLine{
+				view: true,
+				children: routeTreeLines{
+					&routeTreeLine{view: true},
+				},
+			},
+			previous: " └── ",
+			want: []string{
+				" └── ",
+				"      └── ",
+			},
+		},
+		"level1_more_one_child": {
+			line: routeTreeLine{
+				view: true,
+				children: routeTreeLines{
+					&routeTreeLine{view: true},
+				},
+			},
+			previous: " ├── ",
+			want: []string{
+				" ├── ",
+				" │    └── ",
+			},
+		},
+		"root_two_children": {
+			line: routeTreeLine{
+				view: true,
+				children: routeTreeLines{
+					&routeTreeLine{view: true},
+					&routeTreeLine{view: true},
+				},
+			},
+			want: []string{
+				"",
+				" ├── ",
+				" └── ",
+			},
+		},
+		"level1_single_two_children": {
+			line: routeTreeLine{
+				view: true,
+				children: routeTreeLines{
+					&routeTreeLine{view: true},
+					&routeTreeLine{view: true},
+				},
+			},
+			previous: " └── ",
+			want: []string{
+				" └── ",
+				"      ├── ",
+				"      └── ",
+			},
+		},
+		"level1_more_two_children": {
+			line: routeTreeLine{
+				view: true,
+				children: routeTreeLines{
+					&routeTreeLine{view: true},
+					&routeTreeLine{view: true},
+				},
+			},
+			previous: " ├── ",
+			want: []string{
+				" ├── ",
+				" │    ├── ",
+				" │    └── ",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// arrange
+			assert := assert.New(t)
+			ls := routeTreeLines{&tc.line}
+			ls = append(ls, tc.line.children...)
+			// act
+			createRoutes(&tc.line, tc.previous)
+			// assert
+			var got []string
+			for _, l := range ls {
+				got = append(got, l.route)
+			}
+			assert.Equal(tc.want, got)
+		})
+	}
+}
+
+func setLevels(ls *routeTreeLines) {
+	for _, l := range *ls {
+		setLevel(l)
+	}
+}
+
+func setLevel(l *routeTreeLine) {
+	var level int
+	p := l.parent
+	for {
+		if p == nil {
+			break
+		}
+		p = p.parent
+		level++
+	}
+
+	l.level = level
 }

--- a/internal/tree/route_test.go
+++ b/internal/tree/route_test.go
@@ -7,6 +7,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func Test_add(t *testing.T) {
+	// arrange
+	assert := assert.New(t)
+	invisible := routeTreeLine{name: "invisible"}
+	visible := routeTreeLine{name: "visible", view: true}
+	ls := &routeTreeLines{&invisible, &visible}
+	// act
+	ls.add(5, "to add", "extra content", &visible)
+	// assert
+	assert.Equal(3, len(*ls))
+	newLine := (*ls)[2]
+	assert.Equal("", newLine.color)
+	assert.Equal("", newLine.route)
+	assert.Equal(5, newLine.level)
+	assert.Equal("", newLine.link)
+	assert.Equal("to add", newLine.name)
+	assert.Equal("extra content", newLine.additionalContent)
+	assert.True(newLine.view)
+	assert.Equal(visible, *newLine.parent)
+	assert.Equal(newLine, visible.children[0])
+}
+
 func Test_applyDepthFilter(t *testing.T) {
 	n := []string{
 		"parent",
@@ -237,7 +259,8 @@ func Test_applyColors(t *testing.T) {
 	visible := routeTreeLine{name: "visible", view: true}
 	upgrade := routeTreeLine{name: "upgrade", additionalContent: " [v1.2.3]", view: true}
 	linked := routeTreeLine{name: "linked", additionalContent: "see <3>", view: true}
-	ls := &routeTreeLines{&invisible, &visible, &upgrade, &linked}
+	link := routeTreeLine{link: "<3>", name: "the link", view: true}
+	ls := &routeTreeLines{&invisible, &visible, &upgrade, &linked, &link}
 	// act
 	ls.applyColors()
 	// assert
@@ -245,6 +268,8 @@ func Test_applyColors(t *testing.T) {
 	assert.Equal("", visible.color)
 	assert.Equal(colorYellow, upgrade.color)
 	assert.Equal(colorCyan, linked.color)
+	assert.Equal("", link.color)
+	assert.Contains(link.link, colorCyan)
 }
 
 func Test_cleanInvisible(t *testing.T) {

--- a/internal/tree/tree.go
+++ b/internal/tree/tree.go
@@ -2,7 +2,6 @@ package tree
 
 import (
 	"bufio"
-	"errors"
 	"io"
 	"log"
 	"strings"
@@ -61,8 +60,9 @@ func (t *tree) Fill(file io.Reader) {
 		}
 
 		ss := strings.Split(string(line), " ")
-		if len(ss) != 2 {
-			log.Fatal(errors.New("error input"))
+		const lineParts = 2
+		if len(ss) != lineParts {
+			log.Fatal("error input")
 		}
 
 		t.addItem(ss[0], ss[1])

--- a/internal/tree/tree.go
+++ b/internal/tree/tree.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/vc60er/deptree/internal/moduleinfo"
+	"github.com/vc60er/deptree/internal/verbose"
 )
 
 const maxDepth = 20
@@ -18,7 +19,9 @@ type treeItem struct {
 }
 
 type tree struct {
+	verbose          verbose.Verbose
 	depth            int
+	showDroppedChild bool
 	visualizeTrimmed bool
 	showAll          bool
 	colored          bool
@@ -28,7 +31,8 @@ type tree struct {
 }
 
 // NewTree creates a new instance for tree visualization
-func NewTree(depth int, visualizeTrimmed, showAll, colored bool, modInfo moduleinfo.Info) *tree {
+func NewTree(verbose verbose.Verbose, depth int,
+	showDroppedChild, visualizeTrimmed, showAll, colored bool, modInfo moduleinfo.Info) *tree {
 	if depth > maxDepth {
 		depth = maxDepth
 	}
@@ -36,7 +40,9 @@ func NewTree(depth int, visualizeTrimmed, showAll, colored bool, modInfo modulei
 		depth = 1
 	}
 	t := tree{
+		verbose:          verbose,
 		depth:            depth,
+		showDroppedChild: showDroppedChild,
 		visualizeTrimmed: visualizeTrimmed,
 		showAll:          showAll,
 		colored:          colored,
@@ -61,6 +67,7 @@ func (t *tree) Fill(file io.Reader) {
 
 		t.addItem(ss[0], ss[1])
 	}
+	t.verbose.Log1f("%d graph items collected", len(t.items))
 }
 
 // Print prints the collected information to command line (STDOUT) in the given format.
@@ -81,7 +88,9 @@ func (t *tree) Print(asJSON bool) {
 func (t *tree) addItem(name string, childName string) *treeItem {
 	item, ok := t.items[name]
 	if !ok {
-		item = &treeItem{module: t.modInfo.GetModuleAddIfEmpty(name)}
+		item = &treeItem{
+			module: t.modInfo.GetModuleAddIfEmpty(name),
+		}
 		t.items[name] = item
 	}
 

--- a/internal/tree/tree_example_test.go
+++ b/internal/tree/tree_example_test.go
@@ -5,33 +5,72 @@ import (
 	"strings"
 
 	"github.com/vc60er/deptree/internal/moduleinfo"
+	"github.com/vc60er/deptree/internal/verbose"
 )
 
-func ExamplePrint_alltrimmed() {
-	i := moduleinfo.NewInfo()
-	t := NewTree(2, true, true, false, *i)
+func ExamplePrint_allTrimmed() {
+	const (
+		showDroppedChild = false
+		visualizeTrimmed = true
+		showAll          = true
+		colored          = false
+	)
+	v := verbose.Verbose{}
+	i := moduleinfo.NewInfo(v)
+	t := NewTree(v, 2, showDroppedChild, visualizeTrimmed, showAll, colored, *i)
 	t.Fill(graphStringReader())
 	t.Print(false)
 	// Output:
 	// dependency tree with depth 2 for package: github.com/vc60er/deptree, least 2 trimmed item(s)
+	// * tree of duplicate children not drawn (-f not set)
 	//
 	// github.com/vc60er/deptree
 	//  └── github.com/stretchr/testify@v1.8.2
 	//       ├── github.com/davecgh/go-spew@v1.1.1
 	//       ├── github.com/pmezard/go-difflib@v1.0.0
 	//       ├── github.com/stretchr/objx@v0.5.0
-	//       │    └── ...
+	//       │    └── 1 more ...
 	//       └── gopkg.in/yaml.v3@v3.0.1
-	//            └── ...
+	//            └── 1 more ...
 }
 
-func ExamplePrint_all() {
-	i := moduleinfo.NewInfo()
-	t := NewTree(2, false, true, false, *i)
+func ExamplePrint_allTrimmedSomeMore() {
+	const (
+		showDroppedChild = false
+		visualizeTrimmed = true
+		showAll          = true
+		colored          = false
+	)
+	v := verbose.Verbose{}
+	i := moduleinfo.NewInfo(v)
+	t := NewTree(v, 1, showDroppedChild, visualizeTrimmed, showAll, colored, *i)
 	t.Fill(graphStringReader())
 	t.Print(false)
 	// Output:
-	// dependency tree with depth 2 for package: github.com/vc60er/deptree (no visualization for trimmed tree)
+	// dependency tree with depth 1 for package: github.com/vc60er/deptree, least 4 trimmed item(s)
+	// * tree of duplicate children not drawn (-f not set)
+	//
+	// github.com/vc60er/deptree
+	//  └── github.com/stretchr/testify@v1.8.2
+	//       └── 4 more ...
+}
+
+func ExamplePrint_all() {
+	const (
+		showDroppedChild = false
+		visualizeTrimmed = false
+		showAll          = true
+		colored          = false
+	)
+	v := verbose.Verbose{}
+	i := moduleinfo.NewInfo(v)
+	t := NewTree(v, 2, showDroppedChild, visualizeTrimmed, showAll, colored, *i)
+	t.Fill(graphStringReader())
+	t.Print(false)
+	// Output:
+	// dependency tree with depth 2 for package: github.com/vc60er/deptree
+	// * no visualization for trimmed tree (-t not set)
+	// * tree of duplicate children not drawn (-f not set)
 	//
 	// github.com/vc60er/deptree
 	//  └── github.com/stretchr/testify@v1.8.2
@@ -42,17 +81,27 @@ func ExamplePrint_all() {
 }
 
 func ExamplePrint() {
-	i := moduleinfo.NewInfo()
+	const (
+		showDroppedChild = false
+		visualizeTrimmed = false
+		showAll          = false
+		colored          = false
+	)
+	v := verbose.Verbose{}
+	i := moduleinfo.NewInfo(v)
 	i.Fill(upgradeContent())
 
-	t := NewTree(3, false, false, false, *i)
+	t := NewTree(v, 3, showDroppedChild, visualizeTrimmed, showAll, colored, *i)
 	t.Fill(graphStringReader())
 
 	i.Adjust()
 
 	t.Print(false)
 	// Output:
-	// dependency tree with depth 3 for package: github.com/vc60er/deptree, least 2 trimmed item(s) (no visualization for trimmed tree, only upgradable items with parents)
+	// dependency tree with depth 3 for package: github.com/vc60er/deptree, least 2 trimmed item(s)
+	// * no visualization for trimmed tree (-t not set)
+	// * only upgradable items with parents are shown (-a not set)
+	// * duplicate children not shown (-a not set)
 	//
 	// github.com/vc60er/deptree (go1.15)
 	//  └── github.com/stretchr/testify@v1.8.2 (go1.13)

--- a/internal/tree/tree_example_test.go
+++ b/internal/tree/tree_example_test.go
@@ -122,7 +122,6 @@ func upgradeContent() []byte {
 		`{"Path": "gopkg.in/yaml.v3","Version": "v3.0.1"}`,
 	}
 	return []byte(strings.Join(jsonContent, "\n"))
-
 }
 
 func graphStringReader() io.Reader {

--- a/internal/tree/tree_test.go
+++ b/internal/tree/tree_test.go
@@ -9,12 +9,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vc60er/deptree/internal/moduleinfo"
+	"github.com/vc60er/deptree/internal/verbose"
 )
 
 func TestNewTree(t *testing.T) {
 	var tests = map[string]struct {
 		depth            int
 		visualizeTrimmed bool
+		showDroppedChild bool
 		showAll          bool
 		colored          bool
 		wantDepth        int
@@ -28,9 +30,10 @@ func TestNewTree(t *testing.T) {
 			// arrange
 			assert := assert.New(t)
 			require := require.New(t)
-			i := moduleinfo.NewInfo()
+			v := verbose.Verbose{}
+			i := moduleinfo.NewInfo(v)
 			// act
-			got := NewTree(tc.depth, tc.visualizeTrimmed, tc.showAll, tc.colored, *i)
+			got := NewTree(v, tc.depth, tc.showDroppedChild, tc.visualizeTrimmed, tc.showAll, tc.colored, *i)
 			// assert
 			require.NotNil(got.items)
 			assert.Equal(tc.wantDepth, got.depth)
@@ -45,7 +48,8 @@ func TestFill(t *testing.T) {
 	// arrange
 	assert := assert.New(t)
 	require := require.New(t)
-	i := moduleinfo.NewInfo()
+	v := verbose.Verbose{}
+	i := moduleinfo.NewInfo(v)
 	got := tree{items: make(map[string]*treeItem), modInfo: *i}
 	// act
 	file := graphFile("../../test/data/graphfile_small.txt")
@@ -54,10 +58,52 @@ func TestFill(t *testing.T) {
 	// assert
 	require.NotNil(got.items)
 	assert.Equal(13, len(got.items))
-	require.NotNil(got.items["github.com/vc60er/deptree"])
-	assert.Equal(1, len(got.items["github.com/vc60er/deptree"].children))
-	require.NotNil(got.items["github.com/stretchr/testify@v1.8.2"])
-	assert.Equal(4, len(got.items["github.com/stretchr/testify@v1.8.2"].children))
+	// assert root level 0
+	root := got.items["github.com/vc60er/deptree"]
+	require.NotNil(root)
+	assert.Equal(1, len(root.children))
+	// assert level 1
+	level1_1 := got.items["github.com/stretchr/testify@v1.8.2"]
+	require.NotNil(level1_1)
+	assert.Equal(4, len(level1_1.children))
+	// assert level 2
+	level2_1 := got.items["github.com/davecgh/go-spew@v1.1.1"]
+	require.NotNil(level2_1)
+	assert.Equal(0, len(level2_1.children))
+	level2_2 := got.items["github.com/pmezard/go-difflib@v1.0.0"]
+	require.NotNil(level2_2)
+	assert.Equal(0, len(level2_2.children))
+	level2_3 := got.items["github.com/stretchr/objx@v0.5.0"]
+	require.NotNil(level2_3)
+	assert.Equal(1, len(level2_3.children))
+	level2_4 := got.items["gopkg.in/yaml.v3@v3.0.1"]
+	require.NotNil(level2_4)
+	assert.Equal(1, len(level2_4.children))
+	// assert level 3
+	level3_1 := got.items["github.com/stretchr/testify@v1.8.0"]
+	require.NotNil(level3_1)
+	assert.Equal(4, len(level3_1.children))
+	level3_2 := got.items["gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"]
+	require.NotNil(level3_2)
+	assert.Equal(0, len(level3_2.children))
+	// assert level 4
+	level4_1 := got.items["github.com/stretchr/objx@v0.4.0"]
+	require.NotNil(level4_1)
+	assert.Equal(2, len(level4_1.children))
+	// assert level 5
+	level5_1 := got.items["github.com/stretchr/testify@v1.7.1"]
+	require.NotNil(level5_1)
+	assert.Equal(4, len(level5_1.children))
+	// assert level 6
+	level6_1 := got.items["github.com/davecgh/go-spew@v1.1.0"]
+	require.NotNil(level6_1)
+	assert.Equal(0, len(level6_1.children))
+	level6_2 := got.items["github.com/stretchr/objx@v0.1.0"]
+	require.NotNil(level6_2)
+	assert.Equal(0, len(level6_2.children))
+	level6_3 := got.items["gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c"]
+	require.NotNil(level6_3)
+	assert.Equal(1, len(level6_3.children))
 }
 
 func graphFile(graphFile string) *os.File {

--- a/internal/verbose/verbose.go
+++ b/internal/verbose/verbose.go
@@ -1,0 +1,32 @@
+package verbose
+
+import "fmt"
+
+const colorCyan = "\033[36m"
+
+type Verbose struct {
+	verboseLevel int
+}
+
+func NewVerbose(verboseLevel int) Verbose {
+	return Verbose{verboseLevel}
+}
+
+func (v Verbose) Log1f(format string, a ...interface{}) {
+	v.Logf(1, format, a...)
+}
+
+func (v Verbose) Log2f(format string, a ...interface{}) {
+	v.Logf(2, format, a...)
+}
+
+func (v Verbose) Log3f(format string, a ...interface{}) {
+	v.Logf(3, format, a...)
+}
+
+func (v Verbose) Logf(level int, format string, a ...interface{}) {
+	if v.verboseLevel >= level {
+		msg := fmt.Sprintf(format, a...)
+		fmt.Printf("%sVerbose %d: %s%s\n", colorCyan, level, msg, "\033[0m")
+	}
+}


### PR DESCRIPTION
* first occurrence of the child will be processed and shown with all sub-children
* already processed children will be filtered by default
* "-a" show a link to the first processed item (do not filter the line completely)
* "-f" forces to process and show each child with all sub-children (stopped at the given depth level), this means the former behavior, which can lead to hang due to circular dependencies or great amount of work

in addition:
* introduce verbose parameter
* small rework of preamble to reduce line length on terminal
* remove invisible lines before call next step to minimize processing time
* creating of routes before draw to reduce complexity during filtering and open the possibility to change the look in a later step (e.g. for long lines we could reduce count of spaces and dashes)
* increase code coverage
* introduce linter configuration and fix all findings