### PR TITLE
Fix: run `go list` with `-mod=readonly` so deptree works in vendored projects

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,7 +59,7 @@ func getUpgradeContent(upgradeFile string, verbose verbose.Verbose) []byte {
 	if len(upgradeFile) == 0 {
 		fmt.Println("call 'go list -u -m -json all', be patient...")
 		var outbuf, errbuf bytes.Buffer
-		cmd := exec.Command("go", "list", "-u", "-m", "-json", "all")
+		cmd := exec.Command("go", "list", "-mod=readonly", "-u", "-m", "-json", "all")
 		cmd.Stdout = &outbuf
 		cmd.Stderr = &errbuf
 		if err := cmd.Run(); err != nil {


### PR DESCRIPTION
Fixes https://github.com/vc60er/deptree/issues/17